### PR TITLE
Weekly template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,112 @@
 
 How To: <a href="https://github.com/SF-WDI-LABS/shared_modules/blob/master/how-to/homework-submission.md" target="blank">Submit Homework</a> ● <a href="https://github.com/SF-WDI-LABS/shared_modules/blob/master/how-to/request-a-code-review.md" target="blank">Request a Code Review</a>
 
-<!-- Week template -->
-<!-- ## Week 1 - Front End Basics
-
-|  | Monday | Tuesday | Wednesday | Thursday | Friday |
-| :----------: | :----------: | :----------: | :----------: | :----------: | :----------: |
-| **Drills** | [title](link) (name) | [title](link) (name) | [title](link) (name) | [title](link) (name) | [title](link) (name) |
-| **Module 1** | [title](link) (name) | [title](link) (name) | [title](link) (name) | [title](link) (name) | [title](link) (name) |
-| **Module 2** | [title](link) (name) | [title](link) (name) | [title](link) (name) | [title](link) (name) | [title](link) (name) |
-| **Evening Homework** | [title](link) | [title](link) | [title](link) | [title](link) | [title](link) | -->
-
 ## Week 1 - Front End Basics
-
-|  | Monday | Tuesday | Wednesday | Thursday | Friday |
-| :----------: | :----------: | :----------: | :----------: | :----------: | :----------: |
-| **Drills** | [Orientation](link) (ALL) | [Kyrel](link) (name) | [Kyrel](link) (name) | [Kyrel](link) (name) | [Extend Kyrel](link) (name) |
-| **Module 1** | [Orientation](link) (ALL) | [Control Flow](link) (name) | [Array Methods](link) (name) | [jQuery & DOM, Intro Chrome ](link) (name) | [Review](link) (name) |
-| **Module 2** | Assessment <br> [What is the Internet, Terminal, Git/GitHub](link) (name) | [Functions & Arguments](link) (name) | [Bootstrap & class-based css](link) (name) | [DOM Events](link) (name) | [Outcomes](link) (name) |
-| **Evening Homework** | [Command Line Mystery + Growth Mindset Video ](link) | [JS Primitives & Objects](link) | [Selectors review, jQuery prep/ DOM preview, chrome dev tool elements](link) | [Practice jQuery](link) | [Tic-Tac-ToeWeekend Lab](link) |
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 1 - Monday Drill -->
+      Orientation
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Tuesday Drill -->
+      Kyrel
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Wednesday Drill -->
+      Kyrel
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Thursday Drill -->
+      Kyrel
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Friday Review -->
+      Extend Kyrel
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 1 - Monday Morning Module -->
+      Orientation
+      (Team)
+    </td>
+    <td> <!-- Week 1 - Tuesday Morning Module -->
+      Control Flow
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Wednesday Morning Module -->
+      Array Methods
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Thursday Morning Module -->
+      jQuery & DOM, Intro Chrome
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 1 - Monday Afternoon Module -->
+      Assessment
+      <br>
+      What is the Internet, Terminal, Git/GitHub
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Tuesday Afternoon Module -->
+      Functions & Arguments
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Wednesday Afternoon Module -->
+      Bootstrap & class-based css
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Thursday Afternoon Module -->
+      DOM Events
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Friday Afternoon / Weekend Lab -->
+      Outcomes / Tic-Tac-Toe Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 1 - Monday Homework -->
+      Command Line Mystery
+      <br>
+      Growth Mindset Video
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Tuesday Homework -->
+      JS Primitives & Objects
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Wednesday Homework -->
+      Selectors review, jQuery prep/ DOM preview, chrome dev tool elements
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Thursday Homework -->
+      Practice jQuery
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
 
 
 ## Daily Schedule Overview

--- a/_schedule-template.md
+++ b/_schedule-template.md
@@ -1,0 +1,1235 @@
+## Week 12  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 12 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 12 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 12 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 12 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 12 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 11  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 11 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 11 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 11 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 11 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 11 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 10  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 10 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 10 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 10 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 10 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 10 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 9  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 9 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 9 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 9 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 9 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 9 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 8  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 8 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 8 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 8 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 8 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 8 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 7  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 7 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 7 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 7 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 7 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 7 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 6  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 6 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 6 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 6 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 6 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 6 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 5  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 5 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 5 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 5 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 5 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 5 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 4  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 4 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 4 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 4 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 4 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 4 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 3  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 3 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 3 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 3 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 3 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 3 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 2  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 2 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 2 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 2 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 2 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 2 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>
+
+## Week 1  - Topic 
+<table>
+  <tr>
+    <th><!-- BLANK --></th>
+    <th>Monday</th>
+    <th>Tuesday</th>
+    <th>Wednesday</th>
+    <th>Thursday</th>
+    <th>Friday</th>
+  </tr>
+  <tr>
+    <td><strong>Drills</strong></td>
+    <td> <!-- Week 1 - Monday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Tuesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Wednesday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Thursday Drill -->
+      Drill
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Friday Review -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 1</strong></td>
+    <td> <!-- Week 1 - Monday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Tuesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Wednesday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Thursday Morning Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Friday Morning Module -->
+      Review
+      (team)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Module 2</strong></td>
+    <td> <!-- Week 1 - Monday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Tuesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Wednesday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Thursday Afternoon Module -->
+      Topic
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Friday Afternoon / Weekend Lab -->
+      Weekend Lab
+      (tbd)
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Homework</strong></td>
+    <td> <!-- Week 1 - Monday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Tuesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Wednesday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Thursday Homework -->
+      Reading
+      (tbd)
+    </td>
+    <td> <!-- Week 1 - Friday -->
+      <!-- BLANK -->
+    </td>
+  </tr>
+</table>

--- a/_schedule-template.md
+++ b/_schedule-template.md
@@ -1,3 +1,5 @@
+<!-- Due to the fact that comments cannot be nested inside comments this boilerplate cannot live inside / be hidden inside README.md -->
+
 ## Week 12  - Topic 
 <table>
   <tr>


### PR DESCRIPTION
I fear the markdown schedule table is too easy to fat-finger, too hard to know which slot to put things in.

I propose this html table instead. It may be overkill but I've added a ton of comments to clarify the common problem of not knowing which slot is which.

Note: due to the fact that comments cannot be nested in comments it is not possible for the template to be hidden in README.md.

If we do not like the _schedule-template.md file to be in the repo, we can add it to .git-ignore but have a copy on our individual machines.
